### PR TITLE
Update for https://github.com/azerothcore/azerothcore-wotlk/pull/25197

### DIFF
--- a/data/sql/db-world/base/dm_setup.sql
+++ b/data/sql/db-world/base/dm_setup.sql
@@ -19,7 +19,7 @@
 -- -----------------------------------------------
 -- Step 1: Clean slate  (safe DELETE, not TRUNCATE)
 -- -----------------------------------------------
-DELETE FROM `creature`               WHERE `id1` = 500000;
+DELETE FROM `creature`               WHERE `id` = 500000;
 DELETE FROM `creature_template_model` WHERE `CreatureID` = 500000;
 DELETE FROM `creature_template`      WHERE `entry` = 500000;
 
@@ -86,7 +86,7 @@ INSERT INTO `creature_template_model` (
 --
 
 INSERT INTO `creature` (
-    `guid`, `id1`, `map`, `spawnMask`, `phaseMask`,
+    `guid`, `id`, `map`, `spawnMask`, `phaseMask`,
     `position_x`, `position_y`, `position_z`, `orientation`,
     `spawntimesecs`
 ) VALUES

--- a/src/DMBossSpawnQuery.h
+++ b/src/DMBossSpawnQuery.h
@@ -18,7 +18,7 @@ inline std::string BuildBossSpawnPointQuery(uint32 mapId)
         "SELECT c.position_x, c.position_y, c.position_z, c.orientation, "
         "COALESCE(ci.MechanicsMask, 0) AS MechanicsMask, ct.`rank`, ct.entry "
         "FROM creature c "
-        "JOIN creature_template ct ON c.id1 = ct.entry "
+        "JOIN creature_template ct ON c.id = ct.entry "
         "LEFT JOIN creature_immunities ci ON ci.ID = ct.CreatureImmunitiesId "
         "WHERE c.map = " + std::to_string(mapId) + " "
         "AND COALESCE(ci.MechanicsMask, 0) > 0 "

--- a/src/DungeonMasterMgr.cpp
+++ b/src/DungeonMasterMgr.cpp
@@ -331,7 +331,7 @@ void DungeonMasterMgr::LoadDungeonBossPool()
     snprintf(query, sizeof(query),
         "SELECT DISTINCT ct.entry, ct.name, ct.type, ct.minlevel, ct.maxlevel "
         "FROM creature_template ct "
-        "JOIN creature c ON c.id1 = ct.entry "
+        "JOIN creature c ON c.id = ct.entry "
         "LEFT JOIN creature_template_movement ctm ON ct.entry = ctm.CreatureId "
         "WHERE c.map IN (%s) "
         "AND ct.`rank` IN (1, 2) "


### PR DESCRIPTION
Change `id1` to `id` in-line with this merged PR to AzerothCore that refactors this field in the creature tables: https://github.com/azerothcore/azerothcore-wotlk/pull/25197