### PR TITLE
Fix creature.id1 -> creature.id schema mismatch

### DIFF
--- a/data/sql/db-world/base/dm_setup.sql
+++ b/data/sql/db-world/base/dm_setup.sql
@@ -19,7 +19,7 @@
 -- -----------------------------------------------
 -- Step 1: Clean slate  (safe DELETE, not TRUNCATE)
 -- -----------------------------------------------
-DELETE FROM `creature`               WHERE `id1` = 500000;
+DELETE FROM `creature`               WHERE `id` = 500000;
 DELETE FROM `creature_template_model` WHERE `CreatureID` = 500000;
 DELETE FROM `creature_template`      WHERE `entry` = 500000;
 
@@ -86,7 +86,7 @@ INSERT INTO `creature_template_model` (
 --
 
 INSERT INTO `creature` (
-    `guid`, `id1`, `map`, `spawnMask`, `phaseMask`,
+    `guid`, `id`, `map`, `spawnMask`, `phaseMask`,
     `position_x`, `position_y`, `position_z`, `orientation`,
     `spawntimesecs`
 ) VALUES

--- a/src/DMBossSpawnQuery.h
+++ b/src/DMBossSpawnQuery.h
@@ -18,7 +18,7 @@ inline std::string BuildBossSpawnPointQuery(uint32 mapId)
         "SELECT c.position_x, c.position_y, c.position_z, c.orientation, "
         "COALESCE(ci.MechanicsMask, 0) AS MechanicsMask, ct.`rank`, ct.entry "
         "FROM creature c "
-        "JOIN creature_template ct ON c.id1 = ct.entry "
+        "JOIN creature_template ct ON c.id = ct.entry "
         "LEFT JOIN creature_immunities ci ON ci.ID = ct.CreatureImmunitiesId "
         "WHERE c.map = " + std::to_string(mapId) + " "
         "AND COALESCE(ci.MechanicsMask, 0) > 0 "

--- a/src/DungeonMasterMgr.cpp
+++ b/src/DungeonMasterMgr.cpp
@@ -331,7 +331,7 @@ void DungeonMasterMgr::LoadDungeonBossPool()
     snprintf(query, sizeof(query),
         "SELECT DISTINCT ct.entry, ct.name, ct.type, ct.minlevel, ct.maxlevel "
         "FROM creature_template ct "
-        "JOIN creature c ON c.id1 = ct.entry "
+        "JOIN creature c ON c.id = ct.entry "
         "LEFT JOIN creature_template_movement ctm ON ct.entry = ctm.CreatureId "
         "WHERE c.map IN (%s) "
         "AND ct.`rank` IN (1, 2) "


### PR DESCRIPTION
## Summary
- All three `creature`-joining queries in this module still reference the old `id1` column name for the creature spawn table's template-reference column. Current AzerothCore uses `id` instead (the rename happened upstream at some point).
- On any core using the current schema, every one of these queries fails with `Unknown column 'id1'`. AzerothCore's `_HandleMySQLErrno()` treats that class of error as fatal and intentionally writes to a null pointer to force a crash dump (see `src/common/Debugging/Errors.cpp`), so instead of a clean SQL error, the **entire worldserver crashes** — repeatedly, since `restart: unless-stopped`-style setups just bring it back up into the same crash.
- Confirmed via a live crash: WSL/kernel `segfault at 0 ... error 6` (a null-pointer write) resolved through `addr2line`/`objdump` straight back to `Acore::Abort()` being invoked from `_HandleMySQLErrno`, with the accompanying log showing `[1054] Unknown column 'c.id1' in 'on clause'` right before the abort — this PR's fix reproducibly resolved it.

## Changes
- `data/sql/db-world/base/dm_setup.sql`: the NPC cleanup `DELETE` and the city-spawn `INSERT` column list.
- `src/DMBossSpawnQuery.h`: `BuildBossSpawnPointQuery` — boss spawn-point lookup join.
- `src/DungeonMasterMgr.cpp`: `LoadDungeonBossPool` — dungeon boss-cache join.

## Test plan
- [x] Applied the fixed `dm_setup.sql` against a current-schema `acore_world` database — imports cleanly.
- [x] Rebuilt the worldserver with the two C++ fixes and confirmed a clean boot with no crash (previously crashed deterministically on every boot at the boss-spawn-cache step).
- [x] Verified in-game: Dungeon Master NPC present, dungeons populate correctly, no further `id1`-related errors in logs.